### PR TITLE
Add GeoIP support to the bot

### DIFF
--- a/src/SpikeCore/SpikeCore.Web/Startup.cs
+++ b/src/SpikeCore/SpikeCore.Web/Startup.cs
@@ -74,6 +74,8 @@ namespace SpikeCore.Web
                     .AddMvc()
                     .SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
             }
+            
+            services.AddHttpClient();
 
             var containerBuilder = new ContainerBuilder();
 

--- a/src/SpikeCore/SpikeCore.Web/appsettings.json
+++ b/src/SpikeCore/SpikeCore.Web/appsettings.json
@@ -36,6 +36,8 @@
     "Password": "<fill this in>"
   },
   "Modules": {
-    "TriggerPrefix": "~"
+    "TriggerPrefix": "~",
+    "GeoIpApiKey": null,
+    "GeoIpIntelEmailAddress": null
   }
 }

--- a/src/SpikeCore/SpikeCore/Irc/Configuration/ModuleConfiguration.cs
+++ b/src/SpikeCore/SpikeCore/Irc/Configuration/ModuleConfiguration.cs
@@ -3,5 +3,7 @@ namespace SpikeCore.Irc.Configuration
     public class ModuleConfiguration
     {
         public string TriggerPrefix { get; set; }
+        public string GeoIpApiKey { get; set; }        
+        public string GeoIpIntelEmailAddress { get; set; }
     }
 }

--- a/src/SpikeCore/SpikeCore/Modules/GeoIpModule.cs
+++ b/src/SpikeCore/SpikeCore/Modules/GeoIpModule.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Serilog;
+using SpikeCore.MessageBus;
+
+namespace SpikeCore.Modules
+{
+    /// <summary>
+    /// Provides GeoIP-based functionality to the bot, with an optional IP score. The score is computed by a third party
+    /// and the higher it is, the more likely it is to be a proxy, VPN, or known bad actor (i.e. related to attacks).
+    /// </summary>
+    /// 
+    /// <remarks>
+    /// In order to use this module, you will need to register for a free API key at <code>https://ipstack.com/</code>,
+    /// and set it in your appsettings.json file under <code>Modules.GeoIpApiKey</code>.
+    ///
+    /// If you would also like the optional IP scoring, you will need to configure a contact email, and set it as
+    /// <code>Modules.GeoIpIntelEmailAddress</code> in your appsettings.json. Please note that while IpIntel does not
+    /// require you to register, they do require that you give them an email address so that they can contact you in the
+    /// event of feature deprecation or naughty behavior (rather than outright blocking you immediately). It's a cool
+    /// free service, please be respectful.
+    /// </remarks>
+    public class GeoIpModule : ModuleBase
+    {
+        private static readonly Regex Regex = new Regex(@"~geoip\s(.*)?");
+        
+        public override string Name => "GeoIp";
+        public override string Description => "Looks up GeoIp information about a given IP";
+        public override string Instructions => "geoip <ip>";
+
+        private readonly IHttpClientFactory _httpClientFactory;
+
+        public GeoIpModule(IHttpClientFactory httpClientFactory)
+        {
+            _httpClientFactory = httpClientFactory;
+        }
+
+        protected override async Task HandleMessageAsyncInternal(IrcPrivMessage request, CancellationToken cancellationToken)
+        {
+            var match = Regex.Match(request.Text);
+            if (!string.IsNullOrEmpty(Configuration.GeoIpApiKey) && match.Success)
+            {
+                var ip = match.Groups[1].Value.Trim();
+                Task<HttpResponseMessage> ipScoreResponse = null;
+
+                // Only check proxy status if someone has configured a contact email. This is required by the API.
+                if (!string.IsNullOrEmpty(Configuration.GeoIpIntelEmailAddress))
+                {
+                    // This will be slower than our GeoIP lookup, so let's kick it off first.
+                    ipScoreResponse = LookUpIpScore(ip, cancellationToken);
+                }
+
+                var body = await LookUpGeoIp(ip);
+                var parsedGeoIpResponse = JObject.Parse(body);
+
+                // The GeoIP service will give us a 200 even if it failed. The only way we know is to look for a success
+                // property that only seems to exist when the call fails.
+                if (null == parsedGeoIpResponse["success"] || parsedGeoIpResponse["success"].Value<bool>())
+                {
+                    var city = parsedGeoIpResponse["city"].Value<string>() ?? "<unknown city>";                    
+                    var country = parsedGeoIpResponse["country_name"].Value<string>() ?? "<unknown city>";                
+                    var result = $"{ip} resolves to: {city}, {country}.";
+
+                    // Assuming our setup has the proxy check enabled, let's give it some time to try and finish. If it
+                    // doesn't come back within a reasonable period of time we'll respond without it.
+                    if (null != ipScoreResponse && 
+                        (await Task.WhenAny(ipScoreResponse, Task.Delay(2000, cancellationToken)) == ipScoreResponse))
+                    {
+                        // IPIntelligence asks that consumers respect a 429, and try not to call more than 2 queries/sec.
+                        if (ipScoreResponse.Result.StatusCode == HttpStatusCode.TooManyRequests)
+                        {
+                            Log.Warning("We've been throttled by IpIntelligence, adding a backoff...");
+                            await Task.Delay(1000, cancellationToken);
+                        }                       
+                        
+                        var ipIntelResult = await ipScoreResponse.Result.Content.ReadAsStringAsync();
+                        result += $" Getipintel.net scores this at {ipIntelResult} ({ParseIpScoreResponse(ipIntelResult)}).";                                              
+                    }
+
+                    await SendResponse(request, result); 
+                }
+                else
+                {
+                    Log.Warning("Failed to call our GeoIP service. Body: {Body}", body);                    
+                    await SendResponse(request, "Failed calling the GeoIP service, please check the logs.");
+                }                
+            }
+        }
+        
+        private static string ParseIpScoreResponse(string scoreResponse)
+        {
+            double.TryParse(scoreResponse, out var score);
+
+            // Handle known error codes from the service.
+            switch (score)
+            {
+                case double _ when Math.Abs(score - (-1)) < double.Epsilon || Math.Abs(score - (-2)) < double.Epsilon:
+                    return "is an invalid IP";
+                case double _ when Math.Abs(score - (-3)) < double.Epsilon:
+                    return "is a non-public IP";
+                case double _ when Math.Abs(score - (-4)) < double.Epsilon:
+                    return "the service is offline for maintenance";
+                case double _ when Math.Abs(score - (-5)) < double.Epsilon || Math.Abs(score - (-6)) < double.Epsilon:
+                    return "the bot is misconfigured, or has been banned";
+            }
+            
+            // Handle actual scores
+            switch (score)
+            {
+                // Anything under .9 is considered "low risk"
+                case double _ when score > .001 && score < .7:
+                    return "most likely reputable";
+                case double _ when score >= .7 && score < .90:
+                    return "might be reputable";
+                // At around .95 we start to have enough confidence that this might be a proxy.
+                case double _ when score > .90 && score < .95:
+                    return "probably not reputable";
+                case double _ when score >= .95 && score < .99:
+                    return "almost certainly not reputable";
+                // Over .95 it seems likely that there's a proxy. And at anything over .99, we are very, very certain.
+                default:
+                    return score > .99 ? "is a known proxy/VPN/bad actor" : "is known to be reputable";
+            }
+        }
+
+        private Task<string> LookUpGeoIp(string ip)
+        {
+            // API docs are available at https://ipstack.com/documentation.
+            var client = _httpClientFactory.CreateClient();
+            client.BaseAddress = new Uri("http://api.ipstack.com");
+
+            return client.GetStringAsync($"/{ip}?access_key={Configuration.GeoIpApiKey}");
+        }
+        
+        private Task<HttpResponseMessage> LookUpIpScore(string ip, CancellationToken cancellationToken)
+        {
+            // API docs are available at https://getipintel.net/index.php#API.
+            var client = _httpClientFactory.CreateClient();
+            client.BaseAddress = new Uri("http://check.getipintel.net");
+            
+            return client.GetAsync($"check.php?ip={ip}&contact={Configuration.GeoIpIntelEmailAddress}&flags=f", cancellationToken);
+        }
+    }
+}

--- a/src/SpikeCore/SpikeCore/Modules/KarmaModule.cs
+++ b/src/SpikeCore/SpikeCore/Modules/KarmaModule.cs
@@ -13,7 +13,7 @@ namespace SpikeCore.Modules
     {
         public override string Name => "Karma";
         public override string Description => "The wheel in the sky keeps on turning";
-        public override string Instructions => "karma <user>(++|--)" ;
+        public override string Instructions => "karma <user>(++|--)";
 
         private readonly SpikeCoreDbContext _context;       
         private static readonly Regex KarmaRegex = new Regex(@"~karma\s([^\-\+]+)((\-\-)|(\+\+))?");

--- a/src/SpikeCore/SpikeCore/Modules/ModuleBase.cs
+++ b/src/SpikeCore/SpikeCore/Modules/ModuleBase.cs
@@ -19,13 +19,12 @@ namespace SpikeCore.Modules
         public virtual IEnumerable<string> Triggers => new List<string> {Name};
 
         public IMessageBus MessageBus { protected get; set; }
-        public ModuleConfiguration Configuration { private get; set; }
+        public ModuleConfiguration Configuration { protected get; set; }
         
         public Task HandleMessageAsync(IrcPrivMessage message, CancellationToken cancellationToken)
         {
             return Triggers.Any(trigger =>
-                message.Text.StartsWith(Configuration.TriggerPrefix + trigger,
-                    StringComparison.InvariantCultureIgnoreCase) && AccessAllowed(message.IdentityUser))
+                message.Text.StartsWith(Configuration.TriggerPrefix + trigger, StringComparison.InvariantCultureIgnoreCase) && AccessAllowed(message.IdentityUser))
                 ? HandleMessageAsyncInternal(message, cancellationToken)
                 : Task.CompletedTask;
         }

--- a/src/SpikeCore/SpikeCore/SpikeCore.csproj
+++ b/src/SpikeCore/SpikeCore/SpikeCore.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="Foundatio" Version="7.1.1845" />
-    <PackageReference Include="Json.Net" Version="1.0.16" />
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.1" />
@@ -16,6 +15,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.2.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="Serilog" Version="2.7.1" />
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
   </ItemGroup>

--- a/src/SpikeCore/SpikeCore/SpikeCore.csproj
+++ b/src/SpikeCore/SpikeCore/SpikeCore.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Foundatio" Version="7.1.1845" />
+    <PackageReference Include="Json.Net" Version="1.0.16" />
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.1" />
@@ -14,6 +15,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.2.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
     <PackageReference Include="Serilog" Version="2.7.1" />
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
   </ItemGroup>


### PR DESCRIPTION
* Uses `ipstack.com` as the GeoIP vendor for now.
    * It provides a free registration tier with a decent amount of queries per month
    * Seems to be reliable and well recommended

* Optionally enriches the GeoIP lookup with a score from getipintel.net
    * This requires that you give them a valid contact email, but is otherwise free at 2 queries/sec
    * Minimal checking against known TOR nodes seems like it's not completely insane

* Adds two new module configurations in appsettings.json:
    * `GeoIpApiKey` - register a free one at ipstack.com, slap it in here
    * `GeoIpIntelEmailAddress` - this is, as it implies, an email. Slap it in here to use the optional security score enrichment
    * If `GeoIpIntelEmailAddress` is undefined, you can still get location results as long as you provide `GeoIpApiKey`
    * If `GeoIpApiKey` is null, you get nothing (insert Willy Wonka joke here)

* Adds a dependency on `Microsoft.Extensions.Http` at `2.2.0`, and `Json.Net` at `1.0.16`
    * The GeoIP module uses an injected `IHttpClientFactory`, which is configured in our Startup via an extension method
    * We're using Json.NET to parse our API response from ipstack.com

* ModuleConfiguration is now `protected` instead of `private` so modules can grab extra config info now