### PR TITLE
Logging Part 2:

### DIFF
--- a/src/SpikeCore/SpikeCore.Web/SpikeCore.Web.csproj
+++ b/src/SpikeCore/SpikeCore.Web/SpikeCore.Web.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.1" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
   </ItemGroup>
 

--- a/src/SpikeCore/SpikeCore.Web/Startup.cs
+++ b/src/SpikeCore/SpikeCore.Web/Startup.cs
@@ -109,6 +109,10 @@ namespace SpikeCore.Web
                 .SingleInstance();
 
             containerBuilder
+                .RegisterType<LoggingListener>()
+                .SingleInstance();
+
+            containerBuilder
                 .RegisterAssemblyTypes(AppDomain.CurrentDomain.GetAssemblies().Single(assembly => assembly.GetName().Name == "SpikeCore"))
                 .Where(t => t.Name.EndsWith("Module"))
                 .As<IModule>()
@@ -124,6 +128,7 @@ namespace SpikeCore.Web
             
             // We also need to resolve all of our modules.
             container.Resolve<IEnumerable<IModule>>();
+            container.Resolve<LoggingListener>();
 
             return new AutofacServiceProvider(container);
         }

--- a/src/SpikeCore/SpikeCore.Web/appsettings.json
+++ b/src/SpikeCore/SpikeCore.Web/appsettings.json
@@ -10,7 +10,7 @@
     "MinimumLevel": {
       "Default": "Debug",
       "Override": {
-        "Microsoft": "Information"
+        "Microsoft": "Warning"
       }
     },
     "WriteTo": [

--- a/src/SpikeCore/SpikeCore/Irc/LoggingListener.cs
+++ b/src/SpikeCore/SpikeCore/Irc/LoggingListener.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Serilog;
+using SpikeCore.MessageBus;
+
+namespace SpikeCore.Irc
+{
+    public class LoggingListener : IMessageHandler<IrcPrivMessage>
+    {
+        public Task HandleMessageAsync(IrcPrivMessage message, CancellationToken cancellationToken)
+        {
+            Log.Information("{Type} {UserName} ({UserHostName}) -> {ChannelName}: {Text}", 
+                "PRIVMSG", message.UserName, message.UserHostName, message.ChannelName ?? "<PM>", message.Text);
+            
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
* Adds a new LoggingListener. Right now it's just logging PRIVMSG at the `Information` level
    * Uses templatized types so wen can search within Seq more easily

* Drop Microsoft log level to `Warning`: doesn't seem to be much useful at the `Information` level
* Add a dependency for `Serilog.Sinks.Seq` at `4.0.0`
    * This means you can optionally add a `WriteTo` block for `Seq` in your appsettings.json block for `Serilog`