### PR TITLE
Fix help for `factoids` module:

### DIFF
--- a/src/SpikeCore/SpikeCore/Modules/FactoidModule.cs
+++ b/src/SpikeCore/SpikeCore/Modules/FactoidModule.cs
@@ -13,9 +13,9 @@ namespace SpikeCore.Modules
 {
     public class FactoidModule : ModuleBase
     {
-        public override string Name => "factoids";
+        public override string Name => "Factoids";
         public override string Description => "Keeps track of factoids.";
-        public override string Instructions => "factoid <ban|idiot|warn> <message>";
+        public override string Instructions => "<ban|idiot|warn> <message>";
         public override IEnumerable<string> Triggers => new List<string> { "ban", "idiot", "warn" };
 
         private readonly SpikeCoreDbContext _context;


### PR DESCRIPTION
* Remove the word "factoids" from the help string - this shouldn't be here (copy/paste from SpikeLite)
* Proper case the module `Name` property to match other modules