### PR TITLE
Add ability for the bot to run behind a reverse proxy

### DIFF
--- a/src/SpikeCore/SpikeCore.Web/Configuration/WebConfig.cs
+++ b/src/SpikeCore/SpikeCore.Web/Configuration/WebConfig.cs
@@ -3,5 +3,14 @@
     public class WebConfig
     {
         public bool Enabled { get; set; }
+
+        /// <summary>
+        /// Provides a programmatic way of setting the <code>PathBase</code> for requests. This is handy if you're using a setup with
+        /// a reverse proxy that does path trimming. If this property is blank, no <code>PathBase</code> will be set.
+        ///
+        /// see https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/proxy-load-balancer?view=aspnetcore-3.1#other-proxy-server-and-load-balancer-scenarios
+        /// for details.
+        /// </summary>
+        public string PathBase { get; set; }
     }
 }

--- a/src/SpikeCore/SpikeCore.Web/Startup.cs
+++ b/src/SpikeCore/SpikeCore.Web/Startup.cs
@@ -137,8 +137,7 @@ namespace SpikeCore.Web
                 .SingleInstance();
 
             containerBuilder
-                .RegisterAssemblyTypes(AppDomain.CurrentDomain.GetAssemblies()
-                    .Single(assembly => assembly.GetName().Name == "SpikeCore"))
+                .RegisterAssemblyTypes(typeof(IModule).Assembly)
                 .Where(t => t.Name.EndsWith("Module"))
                 .As<IModule>()
                 .PropertiesAutowired()

--- a/src/SpikeCore/SpikeCore.Web/Startup.cs
+++ b/src/SpikeCore/SpikeCore.Web/Startup.cs
@@ -7,12 +7,14 @@ using Autofac.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Serilog;
 using SpikeCore.Data;
 using SpikeCore.Data.Models;
 using SpikeCore.Irc;
@@ -48,6 +50,11 @@ namespace SpikeCore.Web
                 {
                     options.CheckConsentNeeded = context => true;
                     options.MinimumSameSitePolicy = SameSiteMode.None;
+                });
+
+                services.Configure<ForwardedHeadersOptions>(options =>
+                {
+                    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
                 });
             }
 
@@ -130,7 +137,8 @@ namespace SpikeCore.Web
                 .SingleInstance();
 
             containerBuilder
-                .RegisterAssemblyTypes(AppDomain.CurrentDomain.GetAssemblies().Single(assembly => assembly.GetName().Name == "SpikeCore"))
+                .RegisterAssemblyTypes(AppDomain.CurrentDomain.GetAssemblies()
+                    .Single(assembly => assembly.GetName().Name == "SpikeCore"))
                 .Where(t => t.Name.EndsWith("Module"))
                 .As<IModule>()
                 .PropertiesAutowired()
@@ -163,6 +171,17 @@ namespace SpikeCore.Web
                 {
                     app.UseExceptionHandler("/Home/Error");
                     app.UseHsts();
+                }
+
+                if (!string.IsNullOrEmpty(WebConfig.PathBase))
+                {
+                    // If our proxy trims the path, configure our requests appropriately.
+                    Log.Information("Setting the PathBase to {PathBase}", WebConfig.PathBase);
+                    app.Use((context, next) =>
+                    {
+                        context.Request.PathBase = new PathString(WebConfig.PathBase);
+                        return next();
+                    });
                 }
 
                 app.UseHttpsRedirection();

--- a/src/SpikeCore/SpikeCore.Web/appsettings.json
+++ b/src/SpikeCore/SpikeCore.Web/appsettings.json
@@ -4,7 +4,8 @@
   },
   "AllowedHosts": "*",
   "Web": {
-    "Enabled": true
+    "Enabled": true,
+    "PathBase": ""
   },
   "Serilog": {
     "MinimumLevel": {


### PR DESCRIPTION
* Adds a `PathBase` property to the `Web` section in `appsettings.json`
    * This will set the `PathBase` if non-empty
    * This allows for "trimming" proxies, that redirect from `/foo/bar` -> `/bar`
    * Handy for dealing with nginx as a reverse proxy
    * Is equivalent to prefixing all paths with the PathBase (i.e. `/Account` becomes `/foo/Account`)

* Add configuration to respect `X-Forwarded-For` and `X-Forwarded-For-Proto`