### PR TITLE
Add a GitHub Action to do basic CI

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -1,0 +1,25 @@
+name: .NET Core
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.x
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --configuration Release --no-restore
+    - name: Publish
+      run: dotnet publish --configuration Release

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -17,9 +17,15 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.x
+
     - name: Install dependencies
       run: dotnet restore
+      working-directory: src/SpikeCore
+
     - name: Build
       run: dotnet build --configuration Release --no-restore
+      working-directory: src/SpikeCore
+
     - name: Publish
       run: dotnet publish --configuration Release
+      working-directory: src/SpikeCore

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -29,3 +29,12 @@ jobs:
     - name: Publish
       run: dotnet publish --configuration Release
       working-directory: src/SpikeCore
+
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: freenodecsharp/spike_core
+        tags: latest
+        push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
Create a GH Action YAML file that we can use to replace Travis CI

* Runs on `master`, and pull requests to `master`
* Docker build now runs on all branches, but only pushes on `master`
* Otherwise functionally identical

This closes #50.