### PR TITLE
Upgrade from .NET Core 3.1 to .NET 5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
+FROM mcr.microsoft.com/dotnet/aspnet:5.0
 WORKDIR /app
 
 RUN mkdir /app/DB
 
-COPY src/SpikeCore/SpikeCore.Web/bin/Release/netcoreapp3.1/publish /app
+COPY src/SpikeCore/SpikeCore.Web/bin/Release/net5.0/publish /app
 COPY src/SpikeCore/SpikeCore.Web/DB/SpikeCore.db /app/DB
 ENTRYPOINT ["dotnet", "SpikeCore.Web.dll"]

--- a/src/SpikeCore/SpikeCore.Irc.Irc4NetButSmarter/SpikeCore.Irc.Irc4NetButSmarter.csproj
+++ b/src/SpikeCore/SpikeCore.Irc.Irc4NetButSmarter/SpikeCore.Irc.Irc4NetButSmarter.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SpikeCore/SpikeCore.Irc.IrcDotNet/SpikeCore.Irc.IrcDotNet.csproj
+++ b/src/SpikeCore/SpikeCore.Irc.IrcDotNet/SpikeCore.Irc.IrcDotNet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SpikeCore/SpikeCore.MessageBus.Foundatio/SpikeCore.MessageBus.Foundatio.csproj
+++ b/src/SpikeCore/SpikeCore.MessageBus.Foundatio/SpikeCore.MessageBus.Foundatio.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SpikeCore/SpikeCore.Web/SpikeCore.Web.csproj
+++ b/src/SpikeCore/SpikeCore.Web/SpikeCore.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <UserSecretsId>aspnet-SpikeCore.Web-E201EA6B-FD51-4107-8B35-2258C27E66F3</UserSecretsId>
     <TypeScriptToolsVersion>2.8</TypeScriptToolsVersion>
     <LangVersion>latest</LangVersion>
@@ -11,14 +11,14 @@
     <PackageReference Include="Autofac" Version="4.8.1" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.3.1" />
     <PackageReference Include="Foundatio" Version="7.1.1845" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="3.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="3.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.3" />
-    <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="5.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="5.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.7" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.1" />
-    <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="5.0.1" />
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
   </ItemGroup>
 

--- a/src/SpikeCore/SpikeCore.Web/SpikeCore.Web.csproj
+++ b/src/SpikeCore/SpikeCore.Web/SpikeCore.Web.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="5.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="5.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.7" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />

--- a/src/SpikeCore/SpikeCore.Web/Startup.cs
+++ b/src/SpikeCore/SpikeCore.Web/Startup.cs
@@ -56,6 +56,8 @@ namespace SpikeCore.Web
                 {
                     options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
                 });
+                
+                services.AddDatabaseDeveloperPageExceptionFilter();
             }
 
             services.AddDbContext<SpikeCoreDbContext>(options =>
@@ -164,7 +166,7 @@ namespace SpikeCore.Web
                 if (env.IsDevelopment())
                 {
                     app.UseDeveloperExceptionPage();
-                    app.UseDatabaseErrorPage();
+                    app.UseMigrationsEndPoint();
                 }
                 else
                 {

--- a/src/SpikeCore/SpikeCore/SpikeCore.csproj
+++ b/src/SpikeCore/SpikeCore/SpikeCore.csproj
@@ -1,21 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Foundatio" Version="7.1.1845" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="Serilog" Version="2.7.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Took a quick swag at https://docs.microsoft.com/en-us/aspnet/core/migration/31-to-50?view=aspnetcore-5.0&tabs=visual-studio. It looks like upgrading Autofac and Foundatio will be a bit more work, so we can look at them next.

First pass at upgrading:
 * Bump `TargetFramework` from `netcoreapp3.1` to `net5.0` in `csproj` files
 * Bump Microsoft dependencies from 3.x to 5.x
 * Bump Newtonsoft.Json from `12.0.1` to `13.0.1`
 * Bump various Serilog dependencies to latest
 * Update Dockerfile to use `mcr.microsoft.com/dotnet/aspnet:5.0` as the base container image
     * Also update the binary copy to use the new build directory (was `netcoreapp3.1`, now `net5.0`)
 * Move from `UseDatabaseErrorPage` to `AddDatabaseDeveloperPageExceptionFilter` per https://github.com/aspnet/Announcements/issues/432
 
closes #54.